### PR TITLE
web: Fix GzipFilter for /api url-pattern

### DIFF
--- a/kanbanik-web/src/main/webapp/WEB-INF/web.xml
+++ b/kanbanik-web/src/main/webapp/WEB-INF/web.xml
@@ -78,21 +78,19 @@
 		<filter-name>GzipFilter</filter-name>
 		<filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
 		<async-supported>true</async-supported>
+		<init-param>
+			<param-name>methods</param-name>
+			<param-value>GET,POST</param-value>
+		</init-param>
+		<init-param>
+			<param-name>excludePathPatterns</param-name>
+			<param-value>/events/*</param-value>
+		</init-param>
 	</filter>
 
 	<filter-mapping>
 		<filter-name>GzipFilter</filter-name>
-		<url-pattern>/api</url-pattern>
-	</filter-mapping>
-
-	<filter-mapping>
-		<filter-name>GzipFilter</filter-name>
-		<url-pattern>*.js</url-pattern>
-	</filter-mapping>
-
-	<filter-mapping>
-		<filter-name>GzipFilter</filter-name>
-		<url-pattern>*.css</url-pattern>
+		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
 	<!-- Default page to serve -->


### PR DESCRIPTION
Had to explicitly specify support for POST methods in GzipFilter (default only
GETs are compressed)
