### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/kanbanik-dto/src/main/java/com/googlecode/kanbanik/dto/ErrorCodes.java
+++ b/kanbanik-dto/src/main/java/com/googlecode/kanbanik/dto/ErrorCodes.java
@@ -5,4 +5,6 @@ public class ErrorCodes {
 
     public static final int USER_NOT_LOGGED_IN_STATUS = 453;
 
+    private ErrorCodes() {
+    }
 }

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/KanbanikProgressBar.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/KanbanikProgressBar.java
@@ -16,7 +16,10 @@ public class KanbanikProgressBar {
 		dialog.setGlassEnabled(true);
 		dialog.add(new Image(KanbanikResources.INSTANCE.progressBarImage()));
 	}
-	
+
+	private KanbanikProgressBar() {
+	}
+
 	public static void show() {
 		dialog.center();
 	}

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/api/Dtos.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/api/Dtos.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 public class Dtos {
 
+    private Dtos() {
+    }
+
     public static interface BaseDto {
         String getCommandName();
         void setCommandName(String commandName);

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/api/ServerCaller.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/api/ServerCaller.java
@@ -8,6 +8,9 @@ import static com.googlecode.kanbanik.dto.ErrorCodes.USER_NOT_LOGGED_IN_STATUS;
 
 public class ServerCaller {
 
+    private ServerCaller() {
+    }
+
     public static <T, R> void sendRequest(final T dto, final Class<R> responseClass, final ServerCallCallback<R> callback) {
         KanbanikProgressBar.show();
 

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/tag/TagConstants.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/tag/TagConstants.java
@@ -10,4 +10,7 @@ public class TagConstants {
     public static final int TRANSPARENT_INDEX = 0;
 
     public static final int CUSTOM_INDEX = 1;
+
+    private TagConstants() {
+    }
 }

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/messaging/MessageBus.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/messaging/MessageBus.java
@@ -9,7 +9,10 @@ import java.util.Map;
 public class MessageBus {
 	
 	private static Map<Class<?>, List<MessageListener<?>>> listeners;
-	
+
+	private MessageBus() {
+	}
+
 	public static void sendMessage(Message<?> message) {
 		if (message == null) {
 			return;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.