### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/api/ServerEventsListener.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/api/ServerEventsListener.java
@@ -24,8 +24,8 @@ public class ServerEventsListener {
 
     private Atmosphere atmosphere;
 
-    private static final Map<String, Class<?>> eventToDto = new HashMap<String, Class<?>>();
-    private static final Map<String, EventAction> eventToAction = new HashMap<String, EventAction>();
+    private static final Map<String, Class<?>> eventToDto = new HashMap<>();
+    private static final Map<String, EventAction> eventToAction = new HashMap<>();
 
     public static final String DEFAULT_ACTION_NAME = "DEFAULT";
 

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/ListBoxWithAddEditDelete.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/ListBoxWithAddEditDelete.java
@@ -153,7 +153,7 @@ public class ListBoxWithAddEditDelete<T> extends Composite {
 		public void setContent(List<T> content) {
 			if (content == null || content.size() == 0) {
 				clear();
-				this.items = new ArrayList<T>();
+				this.items = new ArrayList<>();
 				resetButtonAvailability();
 				return;
 			}

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/PanelContainingDialog.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/PanelContainingDialog.java
@@ -194,7 +194,7 @@ public class PanelContainingDialog extends DialogBox implements Closable,
 
 	public void addListener(PanelContainingDialolgListener listener) {
 		if (listeners == null) {
-			listeners = new ArrayList<PanelContainingDialog.PanelContainingDialolgListener>();
+			listeners = new ArrayList<>();
 		}
 
 		listeners.add(listener);

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/board/ProjectHeader.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/board/ProjectHeader.java
@@ -100,7 +100,7 @@ public class ProjectHeader extends Composite implements ModulesLifecycleListener
     public void messageArrived(Message<Dtos.ProjectDto> message) {
         Dtos.BoardWithProjectsDto boardWithProjectsDto = DtoFactory.boardWithProjectsDto();
         boardWithProjectsDto.setBoard(board);
-        List<Dtos.ProjectDto> projects = new ArrayList<Dtos.ProjectDto>();
+        List<Dtos.ProjectDto> projects = new ArrayList<>();
         projects.add(project);
         boardWithProjectsDto.setProjectsOnBoard(DtoFactory.projectsDto(projects));
 

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/board/TaskContainer.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/board/TaskContainer.java
@@ -140,7 +140,7 @@ public class TaskContainer extends Composite {
 	}
 
 	public List<TaskDto> getTasks() {
-		List<TaskDto> res = new ArrayList<TaskDto>();
+		List<TaskDto> res = new ArrayList<>();
 
 		for (int i = 0; i < contentPanel.getWidgetCount(); i++) {
 			Widget widget = contentPanel.getWidget(i);

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/common/DataCollector.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/common/DataCollector.java
@@ -15,7 +15,7 @@ public class DataCollector<T> implements MessageListener<T> {
     }
 
     public void init() {
-        data = new ArrayList<T>();
+        data = new ArrayList<>();
     }
 
     public List<T> getData() {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/filter/BoardsFilter.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/filter/BoardsFilter.java
@@ -498,7 +498,7 @@ public class BoardsFilter {
         }
         Dtos.BoardWithProjectsDto boardWithProjectsDto = DtoFactory.boardWithProjectsDto();
         boardWithProjectsDto.setBoard(boardDto);
-        List<Dtos.ProjectDto> projects = new ArrayList<Dtos.ProjectDto>();
+        List<Dtos.ProjectDto> projects = new ArrayList<>();
         projects.add(projectDto);
         boardWithProjectsDto.setProjectsOnBoard(DtoFactory.projectsDto(projects));
 

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/filter/FilterComponent.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/filter/FilterComponent.java
@@ -162,7 +162,7 @@ public class FilterComponent extends Composite implements ModulesLifecycleListen
             filterDataDto = DtoFactory.filterDataDto();
 
             filterDataDto.setFullTextFilter(DtoFactory.fullTextMatcherDataDto());
-            List<Dtos.FilteredEntity> entities = new ArrayList<Dtos.FilteredEntity>();
+            List<Dtos.FilteredEntity> entities = new ArrayList<>();
             filterDataDto.getFullTextFilter().setCaseSensitive(false);
             filterDataDto.getFullTextFilter().setInverse(false);
             filterDataDto.getFullTextFilter().setRegex(false);
@@ -352,7 +352,7 @@ public class FilterComponent extends Composite implements ModulesLifecycleListen
 
 
     private void fillClassOfServices(final BoardsFilter filterObject, final boolean loaded) {
-        List<Dtos.ClassOfServiceDto> sorted = new ArrayList<Dtos.ClassOfServiceDto>(ClassOfServicesManager.getInstance().getAllWithNone());
+        List<Dtos.ClassOfServiceDto> sorted = new ArrayList<>(ClassOfServicesManager.getInstance().getAllWithNone());
 
         Collections.sort(sorted, new Comparator<Dtos.ClassOfServiceDto>() {
             @Override
@@ -387,7 +387,7 @@ public class FilterComponent extends Composite implements ModulesLifecycleListen
         classOfServiceFilter.add(new ClassOfServiceFilterCheckBox(classOfServiceDto, filterObject));
     }
 
-    private DataCollector<Dtos.BoardDto> boardsCollector = new DataCollector<Dtos.BoardDto>();
+    private DataCollector<Dtos.BoardDto> boardsCollector = new DataCollector<>();
 
     private void fillBoards(BoardsFilter filterObject, boolean loaded) {
 
@@ -402,7 +402,7 @@ public class FilterComponent extends Composite implements ModulesLifecycleListen
         }, this));
 
         List<Dtos.BoardDto> boards = boardsCollector.getData();
-        List<Dtos.BoardDto> shallowBoards = new ArrayList<Dtos.BoardDto>();
+        List<Dtos.BoardDto> shallowBoards = new ArrayList<>();
         for (Dtos.BoardDto board : boards) {
             shallowBoards.add(asShallowBoard(board));
         }
@@ -502,7 +502,7 @@ public class FilterComponent extends Composite implements ModulesLifecycleListen
     }
 
 
-    private DataCollector<Dtos.BoardWithProjectsDto> projectsOnBoardsCollector = new DataCollector<Dtos.BoardWithProjectsDto>();
+    private DataCollector<Dtos.BoardWithProjectsDto> projectsOnBoardsCollector = new DataCollector<>();
 
     private void fillProjectsOnBoards(BoardsFilter filterObject, boolean loaded) {
         MessageBus.unregisterListener(GetAllProjectsResponseMessage.class, projectsOnBoardsCollector);
@@ -512,7 +512,7 @@ public class FilterComponent extends Composite implements ModulesLifecycleListen
 
         List<Dtos.BoardWithProjectsDto> boardsWithProjectsDtos = projectsOnBoardsCollector.getData();
 
-        List<Dtos.BoardWithProjectsDto> shallowBoardsWithProjectsDtos = new ArrayList<Dtos.BoardWithProjectsDto>();
+        List<Dtos.BoardWithProjectsDto> shallowBoardsWithProjectsDtos = new ArrayList<>();
         for (Dtos.BoardWithProjectsDto boardWithProjectsDto : boardsWithProjectsDtos) {
             Dtos.BoardWithProjectsDto shallowBoardWithProjectsDto = DtoFactory.boardWithProjectsDto();
             shallowBoardWithProjectsDto.setBoard(asShallowBoard(boardWithProjectsDto.getBoard()));

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/filter/FullTextMatcherFilterComponent.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/filter/FullTextMatcherFilterComponent.java
@@ -146,7 +146,7 @@ public class FullTextMatcherFilterComponent extends Composite {
             fullTextMatcherDataDto.setInverse(inverse.getValue());
             fullTextMatcherDataDto.setRegex(regex.getValue());
 
-            List<Dtos.FilteredEntity> filteredEntities = new ArrayList<Dtos.FilteredEntity>();
+            List<Dtos.FilteredEntity> filteredEntities = new ArrayList<>();
 
             if (ticketId.getValue()) {
                 filteredEntities.add(Dtos.FilteredEntity.TICKET_ID);

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/security/PermissionsEditingComponent.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/security/PermissionsEditingComponent.java
@@ -280,7 +280,7 @@ public class PermissionsEditingComponent extends Composite {
 
     static abstract class ListPermissionEditingComponent<T> extends GlobalPermissionEditingComponent {
 
-        private PanelWithCheckboxes<T> permissions = new PanelWithCheckboxes<T>();
+        private PanelWithCheckboxes<T> permissions = new PanelWithCheckboxes<>();
 
         private Map<Integer, Dtos.PermissionDto> permissionDtoMap;
 

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/AbstractTaskEditingComponent.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/AbstractTaskEditingComponent.java
@@ -159,7 +159,7 @@ public abstract class AbstractTaskEditingComponent {
     }
 
     private Map<String, ClassOfServiceDto> initClassOfServiceToName(List<ClassOfServiceDto> classesOfService) {
-        Map<String, ClassOfServiceDto> res = new HashMap<String, ClassOfServiceDto>();
+        Map<String, ClassOfServiceDto> res = new HashMap<>();
         for (ClassOfServiceDto classOfService : classesOfService) {
             res.put(classOfService.getName(), classOfService);
         }
@@ -168,7 +168,7 @@ public abstract class AbstractTaskEditingComponent {
     }
 
     private Map<String, Dtos.UserDto> initUserToName(List<Dtos.UserDto> users) {
-        Map<String, Dtos.UserDto> res = new HashMap<String, Dtos.UserDto>();
+        Map<String, Dtos.UserDto> res = new HashMap<>();
         for (Dtos.UserDto user : users) {
             res.put(user.getUserName(), user);
         }
@@ -203,7 +203,7 @@ public abstract class AbstractTaskEditingComponent {
     private void fillOracle(Map<String, String> suggestions, MultiWordSuggestOracle oracle) {
         oracle.addAll(suggestions.keySet());
 
-        List<Suggestion> defaults = new ArrayList<Suggestion>();
+        List<Suggestion> defaults = new ArrayList<>();
         for (Map.Entry<String, String> suggestion : suggestions.entrySet()) {
             defaults.add(new SimpleSuggestion(suggestion));
         }
@@ -227,7 +227,7 @@ public abstract class AbstractTaskEditingComponent {
 
 
         classOfServiceToName = initClassOfServiceToName(ClassOfServicesManager.getInstance().getAllWithNone());
-        Map<String, String> classOfServiceSuggestionMap = new HashMap<String, String>();
+        Map<String, String> classOfServiceSuggestionMap = new HashMap<>();
         for (Map.Entry<String, Dtos.ClassOfServiceDto> entry : classOfServiceToName.entrySet()) {
             // enough, no need for description...
             classOfServiceSuggestionMap.put(entry.getKey(), entry.getKey());
@@ -236,7 +236,7 @@ public abstract class AbstractTaskEditingComponent {
         classOfServiceEditor.setValue(getClassOfServiceAsString());
 
         userToName = initUserToName(UsersManager.getInstance().getUsers());
-        Map<String, String> userSuggestionMap = new HashMap<String, String>();
+        Map<String, String> userSuggestionMap = new HashMap<>();
         for (Map.Entry<String, Dtos.UserDto> entry : userToName.entrySet()) {
             userSuggestionMap.put(entry.getKey(), entry.getKey() + " (" + entry.getValue().getRealName() + ")");
         }
@@ -487,7 +487,7 @@ public abstract class AbstractTaskEditingComponent {
         TagEditingComponent tagEditingComponent = new TagEditingComponent();
         TagDeletingComponent tagDeletingComponent = new TagDeletingComponent();
 
-        ListBoxWithAddEditDelete<Dtos.TaskTag> listBox = new ListBoxWithAddEditDelete<Dtos.TaskTag>(
+        ListBoxWithAddEditDelete<Dtos.TaskTag> listBox = new ListBoxWithAddEditDelete<>(
                 "Tags",
 
                 new ListBoxWithAddEditDelete.IdProvider<Dtos.TaskTag>() {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/DeleteTasksMessageListener.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/DeleteTasksMessageListener.java
@@ -69,7 +69,7 @@ public class DeleteTasksMessageListener implements MessageListener<List<TaskDto>
 
         public void okClicked(PanelContainingDialog dialog) {
             GlobalKeyListener.INSTANCE.initialize();
-            List<TaskDto> toSend = new ArrayList<TaskDto>();
+            List<TaskDto> toSend = new ArrayList<>();
             for (TaskDto oneTask : tasksDto) {
                 oneTask.setDescription("");
                 toSend.add(oneTask);

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/GlobalKeyListener.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/GlobalKeyListener.java
@@ -78,7 +78,7 @@ public class GlobalKeyListener implements ModulesLifecycleListener, NativePrevie
     }
 
     private void selectSomeTasks(List<TaskDto> selectedTasks) {
-        final List<String> workflowitemIds = new ArrayList<String>();
+        final List<String> workflowitemIds = new ArrayList<>();
         for (TaskDto task : selectedTasks) {
             workflowitemIds.add(task.getWorkflowitemId());
         }
@@ -124,7 +124,7 @@ public class GlobalKeyListener implements ModulesLifecycleListener, NativePrevie
 
 	class GetSelectedTasksListener implements MessageListener<TaskDto> {
 
-		private List<TaskDto> selectedTasks = new ArrayList<TaskDto>();
+		private List<TaskDto> selectedTasks = new ArrayList<>();
 		
 		@Override
 		public void messageArrived(Message<TaskDto> message) {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/RichTextToolbar.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/RichTextToolbar.java
@@ -46,7 +46,7 @@ public class RichTextToolbar extends Composite {
 	private static final String CSS_ROOT_NAME = "RichTextToolbar";
 	
 	//Color and Fontlists - First Value (key) is the Name to display, Second Value (value) is the HTML-Definition
-	public final static HashMap<String,String> GUI_COLORLIST = new HashMap<String,String>();
+	public final static HashMap<String,String> GUI_COLORLIST = new HashMap<>();
 	static {
 		GUI_COLORLIST.put("White", "#FFFFFF");
 		GUI_COLORLIST.put("Black", "#000000");
@@ -55,7 +55,7 @@ public class RichTextToolbar extends Composite {
 		GUI_COLORLIST.put("Yellow", "yellow");
 		GUI_COLORLIST.put("Blue", "blue");
 	}
-	public final static HashMap<String,String> GUI_FONTLIST = new HashMap<String,String>();
+	public final static HashMap<String,String> GUI_FONTLIST = new HashMap<>();
 	static {
 	    GUI_FONTLIST.put("Times New Roman", "Times New Roman");
 	    GUI_FONTLIST.put("Arial", "Arial");

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/TaskAddingComponent.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/TaskAddingComponent.java
@@ -58,7 +58,7 @@ public class TaskAddingComponent extends AbstractTaskEditingComponent {
 
     @Override
     protected List<Dtos.TaskTag> getTags() {
-        return new ArrayList<Dtos.TaskTag>();
+        return new ArrayList<>();
     }
 
     private String findOrder() {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/TaskDeletingComponent.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/TaskDeletingComponent.java
@@ -32,7 +32,7 @@ public class TaskDeletingComponent implements ClickHandler {
 		MessageBus.sendMessage(ChangeTaskSelectionMessage.deselectAll(this));
 		MessageBus.sendMessage(ChangeTaskSelectionMessage.selectOne(taskGui.getDto(), this));
 		
-		List<TaskDto> list = new ArrayList<TaskDto>();
+		List<TaskDto> list = new ArrayList<>();
 		list.add(taskGui.getDto());
 		MessageBus.sendMessage(new DeleteTasksRequestMessage(list, this));
 	}

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/TaskGui.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/TaskGui.java
@@ -91,7 +91,7 @@ public class TaskGui extends Composite implements MessageListener<TaskDto>, Modu
 
     private DragController dragController;
 
-	private DataCollector<Dtos.BoardDto> boardsCollector = new DataCollector<Dtos.BoardDto>();
+	private DataCollector<Dtos.BoardDto> boardsCollector = new DataCollector<>();
 
 	@UiField
 	Style style;

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/managers/ClassOfServicesManager.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/managers/ClassOfServicesManager.java
@@ -20,7 +20,7 @@ public class ClassOfServicesManager implements MessageListener<Dtos.TaskDto> {
 
 	private static final ClassOfServicesManager INSTANCE = new ClassOfServicesManager();
 	
-	private List<ClassOfServiceDto> classesOfServices = new ArrayList<ClassOfServiceDto>();
+	private List<ClassOfServiceDto> classesOfServices = new ArrayList<>();
 
     private ClassOfServiceChangedListener listener;
 
@@ -55,7 +55,7 @@ public class ClassOfServicesManager implements MessageListener<Dtos.TaskDto> {
 
     public List<ClassOfServiceDto> getAllWithNone() {
 		
-		List<ClassOfServiceDto> merged = new ArrayList<ClassOfServiceDto>();
+		List<ClassOfServiceDto> merged = new ArrayList<>();
 		merged.addAll(classesOfServices);
 		
 		if (merged.size() == 0) {
@@ -66,7 +66,7 @@ public class ClassOfServicesManager implements MessageListener<Dtos.TaskDto> {
 	}
 	
 	public void setClassesOfServices(List<ClassOfServiceDto> dtos) {
-		classesOfServices = new ArrayList<ClassOfServiceDto>(); 
+		classesOfServices = new ArrayList<>(); 
 		for (ClassOfServiceDto dto : dtos) {
 			addClassOfService(dto);
 		}

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/managers/TaskTagsManager.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/managers/TaskTagsManager.java
@@ -22,7 +22,7 @@ public class TaskTagsManager {
 
     private List<Dtos.TaskTag> tags;
 
-    private Map<String, List<String>> taskIdToTagName = new HashMap<String, List<String>>();
+    private Map<String, List<String>> taskIdToTagName = new HashMap<>();
 
     private static Dtos.TaskTag noTag;
 
@@ -45,7 +45,7 @@ public class TaskTagsManager {
 
     private void addTaskTag(String taskId, Dtos.TaskTag toAdd) {
         if (tags == null) {
-            tags = new ArrayList<Dtos.TaskTag>();
+            tags = new ArrayList<>();
         }
 
         if (!taskIdToTagName.containsKey(taskId)) {
@@ -106,7 +106,7 @@ public class TaskTagsManager {
 
     public List<Dtos.TaskTag> getTags() {
         if (tags == null) {
-            return new ArrayList<Dtos.TaskTag>();
+            return new ArrayList<>();
         }
 
         return tags;
@@ -134,7 +134,7 @@ public class TaskTagsManager {
                 return;
             }
 
-            List<String> tagNames = new ArrayList<String>();
+            List<String> tagNames = new ArrayList<>();
             for(String name : taskIdToTagName.get(taskId)) {
                 tagNames.add(name);
             }
@@ -164,7 +164,7 @@ public class TaskTagsManager {
                 return;
             }
 
-            List<String> tagNames = new ArrayList<String>();
+            List<String> tagNames = new ArrayList<>();
             for(Dtos.TaskTag tag : taskTags) {
                 addTaskTag(taskId, tag);
                 tagNames.add(tag.getName());
@@ -175,7 +175,7 @@ public class TaskTagsManager {
                 return;
             }
 
-            for (String tagOfTask : new ArrayList<String>(taskIdToTagName.get(taskId))) {
+            for (String tagOfTask : new ArrayList<>(taskIdToTagName.get(taskId))) {
                 if (!tagNames.contains(tagOfTask)) {
                     taskIdToTagName.get(taskId).remove(tagOfTask);
                     // still some reference?

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/managers/UsersManager.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/managers/UsersManager.java
@@ -108,7 +108,7 @@ public class UsersManager implements MessageListener<Dtos.TaskDto> {
 
 	public List<Dtos.UserDto> getUsers() {
 		if (users == null) {
-			return new ArrayList<Dtos.UserDto>();
+			return new ArrayList<>();
 		}
 
 		Collections.sort(users, new Comparator<Dtos.UserDto>() {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/messaging/MessageBus.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/messaging/MessageBus.java
@@ -33,7 +33,7 @@ public class MessageBus {
 			List<MessageListener<?>> listenersForType) {
 		
 		// the shallow copy is done because the reaction for a sent message can be the calling of unregister something which would lead to concurrent modification exception
-		for (@SuppressWarnings("rawtypes") MessageListener listener : new ArrayList<MessageListener<?>>(listenersForType)) {
+		for (@SuppressWarnings("rawtypes") MessageListener listener : new ArrayList<>(listenersForType)) {
 			listener.messageArrived(message);
 		}
 	}
@@ -58,7 +58,7 @@ public class MessageBus {
 
 	public static void registerListener(Class<?> messageType, MessageListener<?> listener) {
 		if (listeners == null) {
-			listeners = new HashMap<Class<?>, List<MessageListener<?>>>();
+			listeners = new HashMap<>();
 		}
 
 		if (!listeners.containsKey(messageType)) {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/BoardsModule.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/BoardsModule.java
@@ -79,7 +79,7 @@ public class BoardsModule {
     }
 
 	private void addTasks(final Dtos.BoardsWithProjectsDto result) {
-        List<Dtos.TaskDto> linearizedTasks = new ArrayList<Dtos.TaskDto>();
+        List<Dtos.TaskDto> linearizedTasks = new ArrayList<>();
 		for (Dtos.BoardWithProjectsDto boardWithProjects : result.getValues()) {
 			for (Dtos.TaskDto task : boardWithProjects.getBoard().getTasks()) {
 				linearizedTasks.add(task);

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/ConfigureWorkflowModule.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/ConfigureWorkflowModule.java
@@ -104,7 +104,7 @@ public class ConfigureWorkflowModule extends HorizontalPanel implements Kanbanik
         }
 
         String boardId = boardWithProjects.getBoard().getId();
-        List<Dtos.ProjectDto> projectsOnBoard = new ArrayList<Dtos.ProjectDto>();
+        List<Dtos.ProjectDto> projectsOnBoard = new ArrayList<>();
         List<Dtos.ProjectDto> projectDtos = result.getValues() != null ? result.getValues() : new ArrayList<Dtos.ProjectDto>();
         for (Dtos.ProjectDto projectDto : projectDtos) {
             if (projectDto.getBoardIds() == null) {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/boards/BoardsBox.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/boards/BoardsBox.java
@@ -99,9 +99,9 @@ public class BoardsBox extends Composite {
 			
 		}
 		
-		boardsList = new ListBoxWithAddEditDelete<Dtos.BoardWithProjectsDto>(
+		boardsList = new ListBoxWithAddEditDelete<>(
 				"Boards",
-				new IdProvider(), 
+				new IdProvider(),
 				new LabelProvider(),
 				new BoardCreatingComponent(),
 				new BoardEditingComponent(),

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/classofservice/ClassOfServicesListManager.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/classofservice/ClassOfServicesListManager.java
@@ -35,13 +35,13 @@ public class ClassOfServicesListManager implements MessageListener<Dtos.ClassOfS
 	
 	public ListBoxWithAddEditDelete<Dtos.ClassOfServiceDto> create() {
 
-		listComponent=  new ListBoxWithAddEditDelete<Dtos.ClassOfServiceDto>(
-				"Classes Of Service", 
-				new IdProvider(), 
+		listComponent= new ListBoxWithAddEditDelete<>(
+				"Classes Of Service",
+				new IdProvider(),
 				new LabelProvider(),
 				creatingComponent,
 				editingComponent,
-				new ClassOfServiceDeletingComponent(), 
+				new ClassOfServiceDeletingComponent(),
 				new Refresher()
 		);
 		

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/projects/ProjectMovedDropController.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/projects/ProjectMovedDropController.java
@@ -38,7 +38,7 @@ public class ProjectMovedDropController extends FlowPanelDropController {
 	}
 	
 	public void onDrop(DragContext context) {
-		List<Widget> toDrop = new ArrayList<Widget>();
+		List<Widget> toDrop = new ArrayList<>();
 		for (Widget widget : context.selectedWidgets) {
 			if (widget instanceof ProjectWidget) {
 				ProjectWidget projectWidget = (ProjectWidget) widget;

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/workflow/BoardGuiBuilder.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/workflow/BoardGuiBuilder.java
@@ -53,7 +53,7 @@ public class BoardGuiBuilder {
 				Widget workflowitemPlace = createWorkflowitemPlace(dragController, currentItem, project, childTable, workflow.getBoard());
 				workflowitemPlace.addStyleName(style.board());
 				table.setWidget(row, column, workflowitemPlace);
-                List<ExtendedWorkflowitem> nestedChildren = new ArrayList<ExtendedWorkflowitem>();
+                List<ExtendedWorkflowitem> nestedChildren = new ArrayList<>();
                 extendedWorkflowitem.setChildren(nestedChildren);
 				buildBoard(wipLimitGuard, nestedChildren, extendedWorkflowitem, currentItem.getNestedWorkflow(), project, childTable, dragController, 0, 0);
 			} else {

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/workflow/WipLimitGuard.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/modules/editworkflow/workflow/WipLimitGuard.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Stack;
 
 public class WipLimitGuard {
-    private Map<String, ExtendedWorkflowitem> idToWorkflowitem = new HashMap<String, ExtendedWorkflowitem>();
+    private Map<String, ExtendedWorkflowitem> idToWorkflowitem = new HashMap<>();
 
     public void taskCountChanged(String id, int size) {
         int currentNumOfTasks = idToWorkflowitem.get(id).getNumOfTasks();
@@ -53,7 +53,7 @@ public class WipLimitGuard {
     }
 
     private List<ExtendedWorkflowitem> doIncDec(String id, int diff) {
-        List<ExtendedWorkflowitem> path = new ArrayList<ExtendedWorkflowitem>();
+        List<ExtendedWorkflowitem> path = new ArrayList<>();
         ExtendedWorkflowitem current = idToWorkflowitem.get(id);
         do {
             current.add(diff);

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/security/CurrentUser.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/security/CurrentUser.java
@@ -152,7 +152,7 @@ public final class CurrentUser implements MessageListener<Dtos.UserDto> {
 
     private List<Integer> getPermissionTypes() {
         List<Dtos.PermissionDto> permissions = getUser().getPermissions();
-        List<Integer> permissionTypes = new ArrayList<Integer>();
+        List<Integer> permissionTypes = new ArrayList<>();
         for (Dtos.PermissionDto permission : permissions) {
             permissionTypes.add(permission.getPermissionType());
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.