### PR TITLE
Fixing squid:S1319 and squid:S2864

### DIFF
--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/RichTextToolbar.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/components/task/RichTextToolbar.java
@@ -17,6 +17,7 @@
 package com.googlecode.kanbanik.client.components.task;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Element;
@@ -46,7 +47,7 @@ public class RichTextToolbar extends Composite {
 	private static final String CSS_ROOT_NAME = "RichTextToolbar";
 	
 	//Color and Fontlists - First Value (key) is the Name to display, Second Value (value) is the HTML-Definition
-	public final static HashMap<String,String> GUI_COLORLIST = new HashMap<String,String>();
+	public final static Map<String,String> GUI_COLORLIST = new HashMap<String,String>();
 	static {
 		GUI_COLORLIST.put("White", "#FFFFFF");
 		GUI_COLORLIST.put("Black", "#000000");
@@ -55,7 +56,7 @@ public class RichTextToolbar extends Composite {
 		GUI_COLORLIST.put("Yellow", "yellow");
 		GUI_COLORLIST.put("Blue", "blue");
 	}
-	public final static HashMap<String,String> GUI_FONTLIST = new HashMap<String,String>();
+	public final static Map<String,String> GUI_FONTLIST = new HashMap<String,String>();
 	static {
 	    GUI_FONTLIST.put("Times New Roman", "Times New Roman");
 	    GUI_FONTLIST.put("Arial", "Arial");
@@ -477,8 +478,8 @@ public class RichTextToolbar extends Composite {
 	    mylistBox.setVisibleItemCount(1);
 	
 	    mylistBox.addItem(GUI_LISTNAME_FONTS);
-	    for (String name: GUI_FONTLIST.keySet()) {
-	    	mylistBox.addItem(name, GUI_FONTLIST.get(name));
+	    for (Map.Entry<String, String> entry : GUI_FONTLIST.entrySet()) {
+	    	mylistBox.addItem(entry.getKey(), entry.getValue());
 	    }
 	    
 	    return mylistBox;
@@ -491,8 +492,8 @@ public class RichTextToolbar extends Composite {
 	    mylistBox.setVisibleItemCount(1);
 	
 	    mylistBox.addItem(GUI_LISTNAME_COLORS);
-	    for (String name: GUI_COLORLIST.keySet()) {
-	    	mylistBox.addItem(name, GUI_COLORLIST.get(name));
+	    for (Map.Entry<String, String> entry : GUI_COLORLIST.entrySet()) {
+	    	mylistBox.addItem(entry.getKey(), entry.getValue());
 	    }
 	    
 	    return mylistBox;

--- a/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/messaging/MessageBus.java
+++ b/kanbanik-web/src/main/java/com/googlecode/kanbanik/client/messaging/MessageBus.java
@@ -41,9 +41,9 @@ public class MessageBus {
 	private static List<MessageListener<?>> getListenersFor(
 			Message<?> message) {
 		List<MessageListener<?>> listenersForType = null;
-		for (Class<?> clazz : listeners.keySet()) {
-			if (clazz == message.getClass()) {
-				listenersForType = listeners.get(clazz);
+		for (Map.Entry<Class<?>, List<MessageListener<?>>> entry : listeners.entrySet()) {
+			if (entry.getKey() == message.getClass()) {
+				listenersForType = entry.getValue();
 				break;
 			}
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”.
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.